### PR TITLE
Fix tables on small (iPhone SE) screen sizes.

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -288,11 +288,13 @@ label {
 
 /* Tables */
 table {
+    display: block;
+    overflow-x: scroll;
+    overflow-y: hidden;
     border: 1px solid var(--color-bg-secondary);
     border-radius: var(--border-radius);
     border-spacing: 0;
     max-width: 100%;
-    overflow: hidden;
     padding: 0;
 }
 


### PR DESCRIPTION
Lovely little project! Had a bit of trouble reading the table on my iPhone SE.

Displaying the table as `block` and adding `overflow-x: scroll` allows users on small screens to horizontally scroll the full table (even when they get bigger than four columns).