### PR TITLE
Make dropdowns look like other inputs

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -290,8 +290,6 @@ select {
     background: transparent url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSdibGFjaycgaGVpZ2h0PScyNCcgdmlld0Jve…BsNSA1IDUtNXonLz48cGF0aCBkPSdNMCAwaDI0djI0SDB6JyBmaWxsPSdub25lJy8+PC9zdmc+) no-repeat center right;
 }
 
-}
-
 label {
     font-weight: bold;
     margin-bottom: 0.2rem;

--- a/mvp.css
+++ b/mvp.css
@@ -275,10 +275,19 @@ textarea {
 }
 
 input,
+select,
 textarea {
     border: 1px solid var(--color-bg-secondary);
     border-radius: var(--border-radius);
     padding: 0.4rem 0.8rem;
+}
+
+select {
+    width: 100%;
+    -webkit-appearance: none;
+    background: transparent url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSdibGFjaycgaGVpZ2h0PScyNCcgdmlld0Jve…BsNSA1IDUtNXonLz48cGF0aCBkPSdNMCAwaDI0djI0SDB6JyBmaWxsPSdub25lJy8+PC9zdmc+) no-repeat center right;
+}
+
 }
 
 label {

--- a/mvp.css
+++ b/mvp.css
@@ -284,6 +284,8 @@ textarea {
 
 select {
     width: 100%;
+    appearance: none;
+    -moz-appearance: none;
     -webkit-appearance: none;
     background: transparent url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSdibGFjaycgaGVpZ2h0PScyNCcgdmlld0Jve…BsNSA1IDUtNXonLz48cGF0aCBkPSdNMCAwaDI0djI0SDB6JyBmaWxsPSdub25lJy8+PC9zdmc+) no-repeat center right;
 }


### PR DESCRIPTION
This PR makes it so that dropdowns look like every other input. It also includes a janky chevron image I'm very inclined to changing but which served well for illustrative purposes. 

Any feedback is well received.

Before: 

 ![Dropdowns before my change](https://user-images.githubusercontent.com/780560/77564541-a6799f80-6ea1-11ea-8ece-104bbbe9bb7f.png) 

After: 

![image](https://user-images.githubusercontent.com/780560/77565274-bd6cc180-6ea2-11ea-90d7-6b8f7d1e6b11.png)

