### PR TITLE
Replace straight quotes with curly quotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,8 +62,7 @@
         <section id="testimonials">
             <blockquote>
                 <img alt="Quote" src="./img/icon-quote.svg" height="80"><br>
-                "By far the easiest stylesheet I've ever used. It integrates easily into <s>one</s> all of my
-                startup&nbsp;projects."
+                <p>By far the easiest stylesheet I've ever used. It integrates easily into <s>one</s> all of my startup&nbsp;projects.</p>
                 <footer><img alt="MVP.css" src="./img/brand.png" height="36"><br><br><i>- Andy Brewer, Author of
                         MVP.css</i></footer>
             </blockquote>

--- a/mvp.css
+++ b/mvp.css
@@ -427,6 +427,14 @@ blockquote {
     text-align: var(--justify-important);
 }
 
+blockquote p::before {
+    content: '“';
+}
+
+blockquote p::after {
+    content: '”';
+}
+
 blockquote footer {
     color: var(--color-text-secondary);
     display: block;

--- a/mvp.html
+++ b/mvp.html
@@ -58,7 +58,7 @@
         <hr>
         <section>
             <blockquote>
-                "Quote"
+                <p>Quote</p>
                 <footer><i>- Attribution</i></footer>
             </blockquote>
         </section>


### PR DESCRIPTION
Automatically add quotes to a paragraph inside blockquotes. Using curly quotes (“”) instead of straight quotes ("").

Sans-serif (San Francisco):
![Sans-serif curly](https://user-images.githubusercontent.com/24668338/79040585-c3280e00-7be9-11ea-8d64-b0ea75175164.jpg)
instead of
![Sans-serif straight](https://user-images.githubusercontent.com/24668338/79040584-c28f7780-7be9-11ea-9160-0fcedae942ea.jpg)
Serif (Charter):
![Serif curly](https://user-images.githubusercontent.com/24668338/79040577-c0c5b400-7be9-11ea-8968-ddf482f0c038.jpg)
instead of
![Serif straight](https://user-images.githubusercontent.com/24668338/79040582-c1f6e100-7be9-11ea-8a2d-ea550af195db.jpg)