### PR TITLE
Add focus indicators

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -189,6 +189,9 @@ details summary {
 }
 
 details summary:focus {
+    box-shadow:
+      0 0 0 2px var(--color-bg),
+      0 0 0 4px var(--color);
     outline: none;
 }
 
@@ -313,6 +316,9 @@ button:focus,
 input:focus,
 select:focus,
 textarea:focus {
+    box-shadow:
+      0 0 0 2px var(--color-bg),
+      0 0 0 4px var(--color);
     outline: none;
 }
 


### PR DESCRIPTION
Hey there! This is a really great resource, thank you for making it—I really like your work with Custom Properties.

This is a little PR to add focus indicators back into the CSS for interactive elements that have had their native focus ring suppressed. If you're not navigating with a mouse, it can be difficult to [know where you are on the page or what you can take action on](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html).

I used the layered box shadow technique to add a minimal focus ring that (I hope) is inline with the aesthetic you are going for. Here's a gif of it in action:

![Kapture 2020-04-13 at 16 15 59](https://user-images.githubusercontent.com/634191/79157804-3c1e9580-7da3-11ea-8dce-e6d0732d5b8f.gif)
