### PR TITLE
added style for input/button type=reset

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -357,6 +357,14 @@ input[type="radio"]+label {
     top: 1px;
 }
 
+input[type="reset"],
+button[type="reset"] {
+    background: var(--color-shadow);
+    border: 2px solid var(--color);
+    color: var(--color);
+    float: right;
+}
+
 input,
 select,
 textarea {


### PR DESCRIPTION
Created style for `input` or `button` element with `type="reset"` attribute.

Now it will be optically less important than conversion buttons (but not as gray as `disabled` buttons)