### PR TITLE
ensure nav dropdown appears over other navigation

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -165,6 +165,7 @@ nav ul li ul {
     top: 1.7rem;
     white-space: nowrap;
     width: auto;
+    z-index: 1;
 }
 
 nav ul li ul li,


### PR DESCRIPTION
With navigation that wraps, the overlay for the second-level navigation was being hidden behind the primary navigation.

Before:

<img width="153" alt="Screen Shot 2020-11-23 at 10 22 29 PM" src="https://user-images.githubusercontent.com/86842/100043846-3e86aa80-2ddc-11eb-91e3-ec6208d4cfc0.png">

After:

<img width="152" alt="Screen Shot 2020-11-23 at 10 23 27 PM" src="https://user-images.githubusercontent.com/86842/100043853-421a3180-2ddc-11eb-884a-a7b65a929246.png">