### PR TITLE
allow easier mousing over navigation drop-down

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -167,6 +167,16 @@ nav ul li ul {
     width: auto;
 }
 
+nav ul li ul::before {
+  /* fill gap above to make mousing over them easier */
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -0.5rem;
+  height: 0.5rem;
+}
+
 nav ul li ul li,
 nav ul li ul li a {
     display: block;


### PR DESCRIPTION
The gap meant that you had to mouse from the primary navigation to the drop-down quickly, before it disappeared. This adds an invisible buffer to keep the overlay visible when the mouse is in that gap. Leverages [this technique](https://stackoverflow.com/a/48753914/358804) to create a hover-able margin.

Possible this only was a problem with certain font sizes.
Before:

![nav_hover_before](https://user-images.githubusercontent.com/86842/100043794-26169000-2ddc-11eb-9b06-eb4cde494458.gif)

After:

![nav_hover_after](https://user-images.githubusercontent.com/86842/100043796-2878ea00-2ddc-11eb-9a90-6594d0b8b88d.gif)