### PR TITLE
Made P tag 100% wide to allow line breaks within SECTIONs

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -230,6 +230,7 @@ ul li {
 p {
     margin: 0.75rem 0;
     padding: 0;
+    width: 100%;
 }
 
 pre {


### PR DESCRIPTION
By making the `P` tag 100% wide then when used instead of a `SECTION` tag, it will force a line break.

This is in reference to https://github.com/andybrewer/mvp/issues/63

One thing to note, this will then make `P` content left aligned. This is an easy fix by just including `p {text-align:center}` which can be a user override.

Example without the fix

https://codepen.io/michealp/pen/dyvNNzb

Example with the fix (pull request)

https://codepen.io/michealp/pen/eYvgKWB