### PR TITLE
Only apply top border radii on first table header row

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -479,11 +479,11 @@ table thead {
     padding: 0;
 }
 
-table thead th:first-child {
+table thead tr:first-child th:first-child {
     border-top-left-radius: var(--border-radius);
 }
 
-table thead th:last-child {
+table thead tr:first-child th:last-child {
     border-top-right-radius: var(--border-radius);
 }
 


### PR DESCRIPTION
Makes tables that have multiple `tr` elements inside `thead` look nicer.

E.g. based on `index.html`, before:

![Screenshot from 2024-01-17 16-39-38](https://github.com/andybrewer/mvp/assets/41089556/22c76b54-09c9-479a-8bc7-0034224f9a00)

After:

![Screenshot from 2024-01-17 16-39-54](https://github.com/andybrewer/mvp/assets/41089556/0fa97f64-a1d6-479d-a9fd-c885b96e302f)

HTML:

```html
<table>
  <thead>
      <tr>
          <th rowspan="2">Feature</th>
          <th colspan="3">CSS framework</th>
      </tr>
      <tr>
          <th>MVP.css</th>
          <th>No CSS</th>
          <th>Custom CSS</th>
      </tr>
  </thead>
 <!-- ... -->
</table>
```