### PR TITLE
Removed dead link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ NPM: <https://www.npmjs.com/package/mvp.css>
 * <https://bliss.js.org/>
 * <https://chrisbilger.com/>
 * <https://figmage.com/>
-* <https://geozip.xyz>
 * <https://www.mondage.com>
 * <http://nextvita.vercel.app/>
 * <https://searchcode.com/>


### PR DESCRIPTION
https://geozip.xyz (linked to in the SHOWCASE section), is a dead link. Removed it.