### PR TITLE
Add missing comma to restore textarea width

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -425,7 +425,7 @@ textarea {
 }
 
 input[type="text"],
-input[type="password"]
+input[type="password"],
 textarea {
     width: calc(100% - 1.6rem);
 }


### PR DESCRIPTION
I think #115 introduced a small syntax error, which is preventing the textarea width styling from being applied.