### PR TITLE
feat: :sparkles: add `styles` for `dialog` element & its `backdrop`

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,21 +407,12 @@
             </button>
 
             <dialog popover id="dialog-modal">
-                <header class="dialog-header">
-                    <h3>Hello, I am a header of the modal</h3>
-                </header>
-
-                <div class="dialog-content">
-                    <p>
-                        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quos ullam at assumenda cum placeat aperiam
-                        ab error, doloribus eligendi sit. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quos
-                        ullam.
-                    </p>
-                </div>
-
-                <footer class="dialog-footer">
-                    <h3>Hello, I am a footer of the modal</h3>
-                </footer>
+                <h3>Hello, I am a header of the modal</h3>
+                <p>
+                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Quos ullam at assumenda cum placeat aperiam
+                    ab error, doloribus eligendi sit. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quos
+                    ullam.
+                </p>
             </dialog>
         </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -399,6 +399,31 @@
                 <button id="close">Close</button>
             </dialog>
         </section>
+
+        <!-- Dialog HTML Element Example -->
+        <section>
+            <button style="margin-top: 6rem;" popovertarget="dialog-modal" id="openDialog">
+                Open Dialog
+            </button>
+
+            <dialog popover id="dialog-modal">
+                <header class="dialog-header">
+                    <h3>Hello, I am a header of the modal</h3>
+                </header>
+
+                <div class="dialog-content">
+                    <p>
+                        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quos ullam at assumenda cum placeat aperiam
+                        ab error, doloribus eligendi sit. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quos
+                        ullam.
+                    </p>
+                </div>
+
+                <footer class="dialog-footer">
+                    <h3>Hello, I am a footer of the modal</h3>
+                </footer>
+            </dialog>
+        </section>
     </main>
     <footer>
         <hr>

--- a/mvp.css
+++ b/mvp.css
@@ -442,15 +442,101 @@ label {
 
 /* Popups */
 dialog {
+    max-width: 90%;
+    max-height: 85dvh;
+    margin: auto;
+    padding: 0;
     border: 1px solid var(--color-bg-secondary);
-    border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow) var(--color-shadow);
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 50%;
-    z-index: 999;
+    border-radius: 0.5rem;
+    overscroll-behavior: contain;
+    scroll-behavior: smooth;
+    scrollbar-width: none; /* Hide scrollbar for Firefox */
+    -ms-overflow-style: none; /* Hide scrollbar for IE and Edge */
+    scrollbar-color: transparent transparent;
+    animation: bottom-to-top 0.25s ease-in-out forwards;
+}
+
+dialog::-webkit-scrollbar {
+    width: 0;
+    display: none;
+}
+
+dialog::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+dialog::-webkit-scrollbar-thumb {
+    background-color: transparent;
+}
+
+@media (min-width: 650px) {
+    dialog {
+        max-width: 39rem;
+    }
+}
+
+dialog::backdrop {
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+.dialog-header {
+    padding-block: 1.25rem;
+    padding-inline: 1rem;
+    border-bottom: 1px solid var(--color-bg-secondary);
+    position: sticky;
+    top: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: var(--color-bg);
+}
+
+.dialog-header :is(h1, h2, h3, h4, h5, h6) {
+    margin: 0;
+}
+
+.dialog-content {
+    padding-block: 1rem;
+    padding-inline: 1rem;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+}
+
+.dialog-content::-webkit-scrollbar {
+    width: 0;
+}
+
+.dialog-content::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.dialog-content::-webkit-scrollbar-thumb {
+    background-color: transparent;
+}
+
+.dialog-footer {
+    padding-block: 1.25rem;
+    padding-inline: 1rem;
+    border-top: 1px solid var(--color-bg-secondary);
+    position: sticky;
+    bottom: 0;
+    background-color: var(--color-bg);
+}
+
+.dialog-footer :is(h1, h2, h3, h4, h5, h6) {
+    margin: 0;
+}
+
+@keyframes bottom-to-top {
+    0% {
+        opacity: 0;
+        transform: translateY(10%);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 /* Tables */

--- a/mvp.css
+++ b/mvp.css
@@ -479,54 +479,6 @@ dialog::backdrop {
     background-color: rgba(0, 0, 0, 0.5);
 }
 
-.dialog-header {
-    padding-block: 1.25rem;
-    padding-inline: 1rem;
-    border-bottom: 1px solid var(--color-bg-secondary);
-    position: sticky;
-    top: 0;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background-color: var(--color-bg);
-}
-
-.dialog-header :is(h1, h2, h3, h4, h5, h6) {
-    margin: 0;
-}
-
-.dialog-content {
-    padding-block: 1rem;
-    padding-inline: 1rem;
-    overscroll-behavior: contain;
-    -webkit-overflow-scrolling: touch;
-}
-
-.dialog-content::-webkit-scrollbar {
-    width: 0;
-}
-
-.dialog-content::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.dialog-content::-webkit-scrollbar-thumb {
-    background-color: transparent;
-}
-
-.dialog-footer {
-    padding-block: 1.25rem;
-    padding-inline: 1rem;
-    border-top: 1px solid var(--color-bg-secondary);
-    position: sticky;
-    bottom: 0;
-    background-color: var(--color-bg);
-}
-
-.dialog-footer :is(h1, h2, h3, h4, h5, h6) {
-    margin: 0;
-}
-
 @keyframes bottom-to-top {
     0% {
         opacity: 0;


### PR DESCRIPTION
#### Description
This `PR` implements new styles to address an issue with heading elements inside the `dialog` HTML element.

The `goal` is to:
- Ensure there is a beautiful design for the `dialog` HTML element.
- Make additional styles for dialog `header`, `content`, and `footer` to improve the overall UI and UX.

#### Changes Made
- Add new styles for the `dialog` HTML element using some custom CSS properties in the `mvp.css` file.
- Add a style for the `::backdrop` pseudo-element to make sense for the user with some `background-color` and `opacity`.
- Add a new `section` in the `index.html` file to make an example for the `dialog` and its state in the open.

#### Screenshot
![image](https://github.com/user-attachments/assets/c9a911b9-4614-4cae-894a-84f80aad7704)

#### Additional Notes
- If there are any `specific design guidelines` or `additional functionality` to consider, please let me know.
- Feel free to reach out if you have any questions or need further clarification on the changes.
