### PR TITLE
feat: dialog style enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,6 +396,7 @@
 
         <dialog popover id="dialog-modal">
           <h3>Hello, I am a header of the modal</h3>
+          <hr>
           <p>
             Lorem ipsum dolor sit amet consectetur adipisicing elit. Quos ullam at assumenda cum placeat aperiam ab error, doloribus eligendi sit. Lorem ipsum dolor sit amet consectetur adipisicing
             elit. Quos ullam.

--- a/mvp.css
+++ b/mvp.css
@@ -464,7 +464,8 @@ dialog {
   max-width: 90%;
   max-height: 85dvh;
   margin: auto;
-  padding: 0;
+  padding-block: 0;
+  padding-inline: 20px;
   border: 1px solid var(--color-bg-secondary);
   border-radius: 0.5rem;
   overscroll-behavior: contain;

--- a/mvp.css
+++ b/mvp.css
@@ -511,6 +511,10 @@ dialog::backdrop {
   }
 }
 
+dialog hr {
+  margin-block: 1rem;
+}
+
 /* Tables */
 table {
   border: 1px solid var(--color-bg-secondary);


### PR DESCRIPTION
Currently `padding: 0` for `dialog`, making the text collapse to the left side. This PR adds `padding-inline: 20px` to address that, as well as `padding-block: 0` to stay close to the old style vertically.

Caveat: adds some width to the dialog, but I believe the tradeoff is worth it.

Tested on Brave and Safari on macOS 15.x, with screenshots from Brave below.

Old:
![image](https://github.com/user-attachments/assets/03a48931-a545-40df-9dfb-19a63fb35412)

New:
![image](https://github.com/user-attachments/assets/2203f6b9-e818-4c7a-a215-d97c2479dcb2)

The `<hr>` is just extra, as I believe it is a common scenario. Can remove if unwanted.